### PR TITLE
Revert use of env var as not possible, use the new correct broker url

### DIFF
--- a/move2kube/m2k.sw.yml
+++ b/move2kube/m2k.sw.yml
@@ -27,7 +27,7 @@ functions:
     operation: specs/move2kube.yaml#start-transformation
   - name: sendCloudEvent
     type: custom
-    operation: rest:post:$SECRET.broker_url
+    operation: rest:post:http://broker-ingress.knative-eventing.svc.cluster.local/sonataflow-infra/default
   - name: createNotification
     operation: 'specs/notifications.yaml#createNotification'
 states:


### PR DESCRIPTION
Revert use of env var as not possible, use the new correct broker url