### PR TITLE
Change how event is sent and replace protocol prefix in workflow for MTA compliance 

### DIFF
--- a/move2kube/m2k.sw.yml
+++ b/move2kube/m2k.sw.yml
@@ -43,7 +43,7 @@ states:
           arguments:
             workspace-id: ".workspaceId"
             project-id: ".projectId"
-            remote-source: "\"git+ssh://\" + .repositoryURL + \"@\" + .sourceBranch"
+            remote-source: "\"git+\" + (.repositoryURL|sub(\"http(s)://?\";\"ssh://\")) + \"@\" + .sourceBranch"
     transition: GetPlanning
   - name: GetPlanning
     type: operation
@@ -104,7 +104,7 @@ states:
   - name: SaveTransformationOutput
     type: inject
     data:
-      gitRepo: '"ssh://" + .repositoryURL'
+      gitRepo:  (.repositoryURL|sub(\"http(s)?://\";\"ssh://\"))
       branch: .targetBranch
       token: .token
       workspaceId: .workspaceId

--- a/move2kube/m2k.sw.yml
+++ b/move2kube/m2k.sw.yml
@@ -12,6 +12,10 @@ events:
   - name: transformationSavedEvent
     source: ''
     type: transformation_saved
+  - name: saveTransformation
+    source: m2k_swf
+    type: save-transformation
+    kind: produced
 functions:
   - name: systemOut
     type: custom
@@ -98,23 +102,18 @@ states:
             topic: "Move2Kube Workflow"
     transition: SaveTransformationOutput
   - name: SaveTransformationOutput
-    type: operation
-    actions:
-      - functionRef:
-          refName: sendCloudEvent
-          arguments:
-            HEADER_Ce-Id: $WORKFLOW.instanceId
-            HEADER_Ce-Specversion: "1.0"
-            HEADER_Ce-Type: "save-transformation"
-            HEADER_Ce-Source: "m2k_swf"
-            HEADER_Content-Type: "application/json"
-            gitRepo: '"ssh://" + .repositoryURL'
-            branch: .targetBranch
-            token: .token
-            workspaceId: .workspaceId
-            projectId: .projectId
-            transformId: .transformId
-            workflowCallerId: $WORKFLOW.instanceId
+    type: inject
+    data:
+      gitRepo: '"ssh://" + .repositoryURL'
+      branch: .targetBranch
+      token: .token
+      workspaceId: .workspaceId
+      projectId: .projectId
+      transformId: .transformId
+      workflowCallerId: $WORKFLOW.instanceId
+    end:
+      produceEvents:
+        - eventRef: saveTransformation
     transition: WaitForSaveTransformationCompletion
   - name: WaitForSaveTransformationCompletion
     type: switch

--- a/move2kube/schemas/input.json
+++ b/move2kube/schemas/input.json
@@ -9,7 +9,7 @@
           "description": "the git repository URL to be used",
           "type": "string",
           "examples": [
-              "bitbucket.org/gfarache31/m2k-test"
+              "https://bitbucket.org/gfarache31/m2k-test"
           ]
       },
       "sourceBranch": {


### PR DESCRIPTION
Changes for demo:

1. use standard event produce so the broker URL is no longer needed and automatically provided by the sinkbinding
2. as MTA will provide http(s)://<url> as repositoryURL, and as M2K need ssh:// protocol prefix, we need to replace the protocol prefix to ssh