### PR TITLE
Build images with jobs-knative-eventing addon

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,6 @@ on:
         required: false
         type: boolean
         default: true
-      build_arg_quarkus_extensions:
-        required: false
-        type: string
-
-
 env:
   WF_HELM_REPO: rgolangh/serverless-workflows-helm
 
@@ -34,7 +29,7 @@ jobs:
           pipeline/workflow-builder.Dockerfile
         build-args: |
           WF_RESOURCES=${{ inputs.workflow_id }}/
-          QUARKUS_ADD_EXTENSION_ARGS=${{ inputs.build_arg_quarkus_extensions }}
+          QUARKUS_EXTENSIONS=org.kie.kogito:kogito-addons-quarkus-jobs-knative-eventing:999-SNAPSHOT
 
     - name: Push To quay.io
       id: push-to-quay

--- a/.github/workflows/mta-e2e.yaml
+++ b/.github/workflows/mta-e2e.yaml
@@ -14,7 +14,6 @@ jobs:
     secrets: inherit
     with:
       workflow_id: mta
-      build_arg_quarkus_extensions: kogito-addons-quarkus-jobs-service-embedded
       push_pr: false
 
   run-e2e:


### PR DESCRIPTION
Without this add the mta workflow had a bug where the
workflow doesn't end (probably because it was not using the job service)

Signed-off-by: Roy Golan <rgolan@redhat.com>
