### PR TITLE
mta: Back to poll with sleep behaviour

### DIFF
--- a/mta/mta.sw.yaml
+++ b/mta/mta.sw.yaml
@@ -129,18 +129,18 @@ states:
             id: ".taskgroup.id"
         actionDataFilter:
           toStateData: ".taskgroup"
+        sleep:
+          before: PT2S
     name: poll
     type: operation
     transition: checkReportDone
   - name: checkReportDone
-    type: operation
-    actions:
-      - functionRef:
-          refName: getTaskgroup
-          arguments:
-            id: ".taskgroup.id"
-        actionDataFilter:
-          toStateData: ".taskgroup"
+    type: switch
+    dataConditions:
+      - condition: (.taskgroup.state == "Ready" and .taskgroup.tasks[0].state == "Succeeded")
+        transition: NotifyBackstage
+    defaultCondition:
+      transition: poll
     transition: NotifyBackstage
   - name: NotifyBackstage
     type: operation


### PR DESCRIPTION
Post the fix of adding the knative job service addon, the workwaround of
direct call with not async polling is no longer needed.

Signed-off-by: Roy Golan <rgolan@redhat.com>
