### PR TITLE
Bump image builder to main-2024-01-19

### DIFF
--- a/pipeline/workflow-builder.Dockerfile
+++ b/pipeline/workflow-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kiegroup/kogito-swf-builder-nightly:main-2024-01-17 AS builder
+FROM quay.io/kiegroup/kogito-swf-builder-nightly:main-2024-01-19 AS builder
 
 # variables that can be overridden by the builder
 # To add a Quarkus extension to your application


### PR DESCRIPTION
Image builder main-2024-01-19 contains a fix to `nodes.enter` date null violation.
This is required for the Workflow Progress, when viewing the workflow instance.