### PR TITLE
Remove useless property and add comment

### DIFF
--- a/move2kube/application.properties
+++ b/move2kube/application.properties
@@ -4,8 +4,9 @@ mp.messaging.incoming.kogito_incoming_stream.connector=quarkus-http
 mp.messaging.incoming.kogito_incoming_stream.path=/
 mp.messaging.incoming.kogito_incoming_stream.method=POST
 
-
+# This property is used when sending the notification while waiting for Q&A
 move2kube_url=${MOVE2KUBE_URL:http://move2kube-svc.default.svc.cluster.local:8080}
+# This property is used to send requests to the move2kube instance
 quarkus.rest-client.move2kube_yaml.url=${MOVE2KUBE_URL:http://move2kube-svc.default.svc.cluster.local:8080}
-broker_url=${BROKER_URL:http://broker-ingress.knative-eventing.svc.cluster.local/m2k/default}
-quarkus.rest-client.notifications_yaml.url=${BACKSTAGE_NOTIFICATIONS_URL:http://host.minikube.internal:7007/api/notifications/}
+# This property is used to send requests to the backstage notification plugin
+quarkus.rest-client.notifications_yaml.url=${BACKSTAGE_NOTIFICATIONS_URL:http://orchestrator-backstage.orchestrator/api/notifications/}


### PR DESCRIPTION
Property `broker_url` is deleted as env var cannot be used with custom rest action
Added comments for remaining properties to explain where/why they are used