### PR TITLE
ci: Use the mta name in the e2e directly

### DIFF
--- a/.github/workflows/mta-e2e.yaml
+++ b/.github/workflows/mta-e2e.yaml
@@ -79,17 +79,17 @@ jobs:
       - name: Download sonataflow artifacts generated manifests
         uses: actions/download-artifact@v3
         with:
-          name: serverless-workflow-${{ inputs.workflow_id }}
+          name: serverless-workflow-mta
           path: manifests
 
       - name: Download serverless workflows mta image
         uses: actions/download-artifact@v3
         with:
-          name: serverless-workflow-${{ inputs.workflow_id }}.tar:${{ github.sha }}
+          name: serverless-workflow-mta.tar:${{ github.sha }}
 
-      - name: Load ${{ inputs.workflow_id }} workflow image to Kind
+      - name: Load mta workflow image to Kind
         run: |
-          kind load image-archive serverless-workflow-${{ inputs.workflow_id }}.tar:${{ github.sha }}
+          kind load image-archive serverless-workflow-mta.tar:${{ github.sha }}
 
 
       - name: Deploy MTA serverless workflow


### PR DESCRIPTION
no need for an input parameter for a name that is for sure the name of
the workflow we build.
Future work could be to generify this workflow so it could parametrized,
but not at this stage.

Signed-off-by: Roy Golan <rgolan@redhat.com>
