### PR TITLE
ci: Use GH_TOKEN and not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Send PRs to helm repo
       if: ${{ inputs.push_pr }}
       env:
-        GITHUB_TOKEN: ${{ secrets.NEW_HELM_REPO_TOKEN }}
+        GH_TOKEN: ${{ secrets.NEW_HELM_REPO_TOKEN }}
       run: |
           gh repo clone $WF_HELM_REPO helm-repo
           cd helm-repo


### PR DESCRIPTION
Signed-off-by: GitHub Action <action@github.com>
