### PR TITLE
M2K workflow - use K_SINK to produce event instead of rest request to broker

### DIFF
--- a/.github/workflows/move2kube-e2e.yaml
+++ b/.github/workflows/move2kube-e2e.yaml
@@ -97,6 +97,8 @@ jobs:
           ###### workaround till https://issues.redhat.com/browse/FLPATH-892 is solved
           yq  --inplace '.spec.podTemplate.container |= ( . +  {"imagePullPolicy": "IfNotPresent"} )' manifests/01-sonataflow_m2k.yaml
           ###### end workaround
+          
+          yq  --inplace '.spec.podTemplate.container |= ( . +  {"env": [{"name": "K_SINK", "value": "http://broker-ingress.knative-eventing.svc.cluster.local/sonataflow-infra/default"}]} )' manifests/01-sonataflow_m2k.yaml
 
           # deploy the manifests created by the  ${{ steps.build-image.outputs.image }}"                                                                    
           kubectl apply -f manifests

--- a/move2kube/m2k.sw.yml
+++ b/move2kube/m2k.sw.yml
@@ -16,6 +16,9 @@ events:
   - name: transformationSavedEvent
     source: ''
     type: transformation_saved
+  - name: saveTransformationEvent
+    source: ''
+    type: save-transformation
 functions:
   - name: systemOut
     type: custom
@@ -29,9 +32,6 @@ functions:
   - name: startTransformation
     type: rest
     operation: specs/move2kube.yaml#start-transformation
-  - name: sendCloudEvent
-    type: custom
-    operation: rest:post:http://broker-ingress.knative-eventing.svc.cluster.local/sonataflow-infra/default
   - name: createNotification
     operation: notifications#createNotification
 states:
@@ -103,37 +103,22 @@ states:
             actions:
               - title: "Move2Kube waiting Q&A"
                 url: "$SECRET.move2kube_url + \"/workspaces/\"+ .workspaceId + \"/projects/\" + .projectId + \"/outputs/\"+ .transformId "
-    transition: SaveTransformationOutput
-  - name: SaveTransformationOutput
-    type: operation
-    actions:
-      - functionRef:
-          refName: sendCloudEvent
-          arguments:
-            HEADER_Ce-Id: $WORKFLOW.instanceId
-            HEADER_Ce-Specversion: "1.0"
-            HEADER_Ce-Type: "save-transformation"
-            HEADER_Ce-Source: "m2k_swf"
-            HEADER_Content-Type: "application/json"
-            gitRepo: "(.repositoryURL|sub(\"http(s)?://\";\"ssh://\"))"
-            branch: .targetBranch
-            token: .token
-            workspaceId: .workspaceId
-            projectId: .projectId
-            transformId: .transformId
-            workflowCallerId: $WORKFLOW.instanceId
-    transition: WaitForSaveTransformationCompletion
-  - name: WaitForSaveTransformationCompletion
+    transition:
+      nextState: WaitForSaveTransformationCompletionEvent
+      produceEvents:
+        - eventRef: saveTransformationEvent
+          data: "{gitRepo:.repositoryURL|sub(\"http(s)?://\";\"ssh://\"), branch: .targetBranch, token: .token, workspaceId: .workspaceId, projectId: .projectId, transformId: .transformId, workflowCallerId: $WORKFLOW.instanceId}"
+  - name: WaitForSaveTransformationCompletionEvent
     type: switch
     eventConditions:
-      - eventRef: transformationSavedEvent
-        transition: TransformationSaved
       - eventRef: errorEvent
         transition: TransformationError
+      - eventRef: transformationSavedEvent
+        transition: TransformationSaved
     defaultCondition:
       transition: TransformationError
     timeouts:
-      eventTimeout: PT3M
+      eventTimeout: P90D
   - name: TransformationSaved
     type: inject
     data:

--- a/pipeline/workflow-builder.Dockerfile
+++ b/pipeline/workflow-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kiegroup/kogito-swf-builder-nightly:main-2024-02-13 AS builder
+FROM quay.io/kiegroup/kogito-swf-builder-nightly:main-2024-02-16 AS builder
 
 # variables that can be overridden by the builder
 # To add a Quarkus extension to your application


### PR DESCRIPTION
Use K_SINK to produce event instead of rest request to broker

The K_SINK env variable should be added to the deployment resource or injected by creating SinkBinding

Closes: https://issues.redhat.com/browse/FLPATH-934