### PR TITLE
Bump kn-workflow and use the --namespace flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,9 +66,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: setup kn-workflow
-      run: curl -L https://github.com/rgolangh/kie-tools/releases/download/0.0.1/kn-workflow -o kn-workflow && chmod +x kn-workflow
+      run: curl -L https://github.com/rgolangh/kie-tools/releases/download/0.0.2/kn-workflow-linux-amd64 -o kn-workflow && chmod +x kn-workflow
     - name: kn-workflow
-      run: cd ${{ inputs.workflow_id }} && ../kn-workflow gen-manifest
+      run: cd ${{ inputs.workflow_id }} && ../kn-workflow gen-manifest --namespace ""
     - name: Remove dev profile
       run: yq -i 'del(.metadata.annotations."sonataflow.org/profile")' ${{ inputs.workflow_id }}/manifests/01-sonataflow*.yaml
     - name: Set container image ref in SonataFlow resource


### PR DESCRIPTION
The generated manifests will be created with no `Namespace: ` field

Fixes #12

Signed-off-by: Roy Golan <rgolang@redhat.com>
