### PR TITLE
Bump dockerfile base image to have fix for null arrays with notifications

### DIFF
--- a/pipeline/workflow-builder.Dockerfile
+++ b/pipeline/workflow-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kiegroup/kogito-swf-builder-nightly:main-2024-01-24 AS builder
+FROM quay.io/kiegroup/kogito-swf-builder-nightly:main-2024-02-01 AS builder
 
 # variables that can be overridden by the builder
 # To add a Quarkus extension to your application


### PR DESCRIPTION
Bump dockerfile base image to have fix for null arrays
And set `targetUser` and `targetGroups` as empty arrays otherwise we get the same error when sending notifications