### PR TITLE
Fix CI for move2kube - issue with secrets loading

### DIFF
--- a/.github/workflows/move2kube-e2e.yaml
+++ b/.github/workflows/move2kube-e2e.yaml
@@ -2,7 +2,7 @@ name: Move2kube Workflow end to end tests
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:


### PR DESCRIPTION
I seems that secrets are not loaded when using `pull_request` for PR coming from fork repo
using `pull_request_target` should solve the issue

https://github.com/actions/add-to-project/issues/163
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target