### PR TITLE
Pass Git token to all makefile calls

### DIFF
--- a/.github/workflows/workflow-executor.yml
+++ b/.github/workflows/workflow-executor.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Build
       run: |
         make WORKFLOW_ID=${{ inputs.workflow_id }} \
+          GIT_TOKEN=${{ env.GH_TOKEN }} \
           REGISTRY_REPO=${{ env.REGISTRY_REPO }} \
           REGISTRY_USERNAME=${{ secrets.NEW_QUAY_USERNAME }} \
           REGISTRY_PASSWORD=${{ secrets.NEW_QUAY_PASSWORD }} \


### PR DESCRIPTION
This is due to fix broken build action: https://github.com/parodos-dev/serverless-workflows/actions/runs/7901926124

Passing Git token to all Makefile calls
Note: I tried to apply the check variable only to the target that actually uses it (e.g. push_manifests) but I didn't succeed. Issue https://github.com/parodos-dev/serverless-workflows/issues/112 tracks a possible enhancement