### PR TITLE
Increase timeout for sonataflow-platform readiness

### DIFF
--- a/.github/workflows/move2kube-e2e.yaml
+++ b/.github/workflows/move2kube-e2e.yaml
@@ -83,9 +83,9 @@ jobs:
           kubectl get pv
           sleep 3m
           kubectl get sfp -A
-          kubectl wait --for=condition=Ready=true pods -l "app.kubernetes.io/name=backstage" --timeout=120s
+          kubectl wait --for=condition=Ready=true pods -l "app.kubernetes.io/name=backstage" --timeout=180s
           kubectl get pods -o wide
-          kubectl wait --for=condition=Ready=true pods -l "app=sonataflow-platform" --timeout=120s
+          kubectl wait --for=condition=Ready=true pods -l "app=sonataflow-platform" --timeout=180s
 
       - name: Deploy Move2kube serverless workflow
         run: |


### PR DESCRIPTION
CI https://github.com/parodos-dev/serverless-workflows/actions/runs/7970427241/job/21758097702 fails on sonataflow-operator installation due to expiring timeout while waiting on sonataflow-platform readiness

The pod is still in init:
```
NAME                                                      READY   STATUS            RESTARTS   AGE
devmode-5[6](https://github.com/parodos-dev/serverless-workflows/actions/runs/7970427241/job/21758097702#step:15:7)98bb9f88-lkg8t                                  1/1     Running           0          5m1s
janus-idp-workflows-backstage-6bfd9bc[7](https://github.com/parodos-dev/serverless-workflows/actions/runs/7970427241/job/21758097702#step:15:8)[8](https://github.com/parodos-dev/serverless-workflows/actions/runs/7970427241/job/21758097702#step:15:9)-bflmw             0/1     Running           0          5m1s
janus-idp-workflows-postgresql-0                          1/1     Running           0          5m1s
knative-operator-644f74cfb7-ct82x                         1/1     Running           0          5m1s
move2kube-instance-6f5d7b5ffd-zfs5v                       1/1     Running           0          5m37s
operator-webhook-857[9](https://github.com/parodos-dev/serverless-workflows/actions/runs/7970427241/job/21758097702#step:15:10)b88d6c-2hqmx                         1/1     Running           0          5m1s
sonataflow-operator-controller-manager-69c8dc75c9-dpgkt   2/2     Running           0          5m1s
sonataflow-platform-cache                                 0/1     PodInitializing   0          31s
```
So I increased the timeout duration to see if that fixes the issue

Far from ideal solution so we would think on how to improve that (maybe changing helm repo will help when ready?)