### PR TITLE
Update references to new target repository name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
         type: boolean
         default: true
 env:
-  WF_HELM_REPO: parodos-dev/serverless-workflows-helm
+  WF_HELM_REPO: parodos-dev/serverless-workflows-config
 
 jobs:
   build:

--- a/.github/workflows/workflow-executor.yml
+++ b/.github/workflows/workflow-executor.yml
@@ -16,7 +16,7 @@ on:
         default: true
 
 env:
-  DEPLOYMENT_REPO: parodos-dev/serverless-workflows-helm
+  DEPLOYMENT_REPO: parodos-dev/serverless-workflows-config
   REGISTRY_REPO: orchestrator
   GH_TOKEN: ${{ secrets.HELM_REPO_TOKEN }}
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ else
 IMAGE_NAME = $(REGISTRY)/$(REGISTRY_REPO)/$(IMAGE_PREFIX)-$(APPLICATION_ID)
 endif
 
-DEPLOYMENT_REPO ?= parodos-dev/serverless-workflows-helm
+DEPLOYMENT_REPO ?= parodos-dev/serverless-workflows-config
 DEPLOYMENT_BRANCH ?= main
 
 .PHONY: all

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ with [Sonataflow operator][2] running.
 4. create a pull request but don't merge yet.
 5. Send a pull request to [the helm chart repo][3] to add a sub-chart 
    under the path `charts/workflows/charts/onboarding`. You can copy the greeting sub-chart directory and files. 
-6. Create a PR to [serverless-workflows-helm][3] and make sure its merge.
+6. Create a PR to [serverless-workflows-config][3] and make sure its merge.
 7. Now the PR from 4 can be merged and an automatic PR will be created with the generated manifests. Review and merge. 
    
 See [Continuous Integration with make](make.md) for implemantation details of the CI pipeline.
@@ -46,4 +46,4 @@ recreate the token. This should be revised.
 
 [1]: https://github.com/serverlessworkflow/specification/blob/main/specification.md
 [2]: https://github.com/apache/incubator-kie-kogito-serverless-operator/
-[3]: https://github.com/parodos-dev/serverless-workflows-helm
+[3]: https://github.com/parodos-dev/serverless-workflows-config

--- a/make.md
+++ b/make.md
@@ -44,7 +44,7 @@ Variables can be used to configure the behavior of the [Makefile](./Makefile):
 | REGISTRY_PASSWORD | Container registry user password | `""`  (e.g., no login attempted) |
 | IMAGE_PREFIX | Automatically added image prefix | `serverless-workflow` |
 | IMAGE_TAG | Automatically added image tag | 8 chars commit hash of the latest commit |
-| DEPLOYMENT_REPO | Git repo of the deployment source code | `parodos-dev/serverless-workflows-helm` |
+| DEPLOYMENT_REPO | Git repo of the deployment source code | `parodos-dev/serverless-workflows-config` |
 | DEPLOYMENT_BRANCH | Branch of the deployment git repo | `main` |
 
 Override the default values with:
@@ -65,7 +65,7 @@ make <VAR1>=<VALUE1> ... <VARn>=<VALUEn> <TARGET>
 See the [setup](./setup/README.md) documentation.
 
 ### Requirements for the deployment repo
-The procedure assumes that the folder structure of the target deployment repository reflects the one of the [default repository](https://github.com/parodos-dev/serverless-workflows-helm), e.g.:
+The procedure assumes that the folder structure of the target deployment repository reflects the one of the [default repository](https://github.com/parodos-dev/serverless-workflows-config), e.g.:
 * `kustomize` projects are located under the `kustomize/WORKFLOW_ID` folder
   * Manifests are stored in the `base` subfolder
   * Image is customized in the `overlays/prod` subfolder


### PR DESCRIPTION
The repository parodos-dev/serverless-workflows-helm was renamed to parodos-dev/serverless-workflow-config to better reflect its responsiblity.