### PR TITLE
Fix move2kube instance for e2e

### DIFF
--- a/e2e/resources/move2kube-instance.yaml
+++ b/e2e/resources/move2kube-instance.yaml
@@ -35,7 +35,7 @@ spec:
           lifecycle:
             postStart:
               exec:
-                command: [ "/bin/sh", "-c", "ssh-agent -a /tmp/unix-socket && ssh-add /root/.ssh/id_rsa" ]
+                command: [ "/bin/sh", "-c", "ssh-agent -a /tmp/unix-socket && ssh-add /root/.ssh/id_rsa && ssh git@github.com -o StrictHostKeyChecking=accept-new || true && ssh git@gitlab.com -o StrictHostKeyChecking=accept-new|| true && ssh git@bitbucket.org -o StrictHostKeyChecking=accept-new|| true" ]
       volumes:
         - name: ssh-priv-key
           secret:


### PR DESCRIPTION
Fix move2kube instance for e2e after changes were made to image, similar changes were made in https://github.com/parodos-dev/serverless-workflows-config/pull/107 but were missed in this