### PR TITLE
Improve Makefile to only check for GIT_TOKEN if target using it is called

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,13 @@ GIT_REMOTE_URL := $(shell echo "$(GIT_REMOTE_URL)" | sed 's/\.git//')
 GIT_REMOTE_URL := $(shell echo "$(GIT_REMOTE_URL)" | sed 's/git@/https:\/\//')
 GIT_REMOTE_URL := $(shell echo "$(GIT_REMOTE_URL)" | sed 's/com:/com\//')
 PR_OR_COMMIT_URL ?= "$(GIT_REMOTE_URL)/commits/$(shell git rev-parse --short=8 HEAD)"
-ifndef GIT_TOKEN
-ifeq ($(wildcard .git_token),)
-$(error No Git token found. Please provide it either via the GIT_TOKEN variable or the .git_token file)
-endif
-GIT_TOKEN ?= $(shell cat .git_token)
+ifneq (,$(findstring push-manifests,$(MAKECMDGOALS)))
+  ifndef GIT_TOKEN
+    ifeq ($(wildcard .git_token),)
+      $(error No Git token found. Please provide it either via the GIT_TOKEN variable or the .git_token file )
+    endif
+    GIT_TOKEN ?= $(shell cat .git_token)
+  endif
 endif
 
 LINUX_IMAGE ?= quay.io/orchestrator/ubi9-pipeline:latest


### PR DESCRIPTION
Currently, everytime the Makefile is called, it is checking that GIT_TOKEN (or .git_token) is provided, no matter which target is called.

But the GIT_TOKEN is only called in the `push-manifests` target, making it useless when calling only others targets.

This PR improves the Makefile by only checking the GIT_TOKEN existence if the `push-manifest` is invoked