### PR TITLE
Add --user root to application build

### DIFF
--- a/scripts/build_application.sh
+++ b/scripts/build_application.sh
@@ -9,5 +9,5 @@ MVN_OPTS=$6
 
 cd "${WORKDIR}"/"${WORKFLOW_ID}"/"${APPLICATION_ID}" || exit
 ${CONTAINER_ENGINE} run --rm -v "${WORKDIR}":/workdir -e MVN_OPTS="${MVN_OPTS}" -w /workdir/"${WORKFLOW_ID}"/"${APPLICATION_ID}" \
-  "${JDK_IMAGE}" mvn "${MVN_OPTS}" clean package -DskipTests
+  --user root "${JDK_IMAGE}" mvn "${MVN_OPTS}" clean package -DskipTests
 


### PR DESCRIPTION
Add the flag to allow building the application under the /workdir/$workflow_id/$application_id/target
Otherwise, the build fails due to a lack of permission to write to that folder.