### PR TITLE
FLPATH-1267: fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,26 +17,26 @@ in the form of `quay.io/orchestrator/serverless-workflow-${workflow}`.
 ## Current image statuses:
 
 - https://quay.io/repository/orchestrator/serverless-workflow-mta
-- https://quay.io/repository/orchestrator/serverless-workflow-m2k 
+- https://quay.io/repository/orchestrator/serverless-workflow-m2k
 - https://quay.io/repository/orchestrator/serverless-workflow-greeting
 - https://quay.io/repository/orchestrator/serverless-workflow-escalation
 
 
 After image publishing, github action will generate kubernetes manifests and push a PR to [the workflows helm chart repo][3]
-under a directory matching the workflow name. This repo is used to deploy the workflows to an environment 
-with [Sonataflow operator][2] running. 
+under a directory matching the workflow name. This repo is used to deploy the workflows to an environment
+with [Sonataflow operator][2] running.
 
 ## To introduce a new workflow
 1. create a folder under the root with the name of the flow, e.x `/onboarding`
-2. copy `application.properties`, `onboarding.sw.yaml` into that folder  
-3. create a github workflow file `.github/workflows/${workflow}.yaml` that will call `main` workflow (see greeting.yaml) 
+2. copy `application.properties`, `onboarding.sw.yaml` into that folder
+3. create a github workflow file `.github/workflows/${workflow}.yaml` that will call `main` workflow (see greeting.yaml)
 4. create a pull request but don't merge yet.
-5. Send a pull request to [the helm chart repo][3] to add a sub-chart 
-   under the path `charts/workflows/charts/onboarding`. You can copy the greeting sub-chart directory and files. 
+5. Send a pull request to [the helm chart repo][3] to add a sub-chart
+   under the path `charts/workflows/charts/onboarding`. You can copy the greeting sub-chart directory and files.
 6. Create a PR to [serverless-workflows-config][3] and make sure its merge.
-7. Now the PR from 4 can be merged and an automatic PR will be created with the generated manifests. Review and merge. 
-   
-See [Continuous Integration with make](make.md) for implementation details of the CI pipeline.
+7. Now the PR from 4 can be merged and an automatic PR will be created with the generated manifests. Review and merge.
+
+See [Continuous Integration with make](https://github.com/parodos-dev/serverless-workflows/blob/main/make.md) for implementation details of the CI pipeline.
 
 ### Builder image
 There are two builder images under ./pipeline folder:
@@ -48,11 +48,11 @@ There are two builder images under ./pipeline folder:
 
 
 Note on CI:
-On each merge under a workflow directory a matching github workflow executes 
-an image build, generating manifests and a PR create on the [helm chart repo][3]. 
-The credentials of this repo are an org level secret, and the content is from a token 
-on the helm repo with an expiry period of 60 days. Currently only the repo owner (rgolangh) can 
-recreate the token. This should be revised. 
+On each merge under a workflow directory a matching github workflow executes
+an image build, generating manifests and a PR create on the [helm chart repo][3].
+The credentials of this repo are an org level secret, and the content is from a token
+on the helm repo with an expiry period of 60 days. Currently only the repo owner (rgolangh) can
+recreate the token. This should be revised.
 
 [1]: https://github.com/serverlessworkflow/specification/blob/main/specification.md
 [2]: https://github.com/apache/incubator-kie-kogito-serverless-operator/


### PR DESCRIPTION
Reference to make.md did not contain the full url. This PR fixes the issue together with trailing spaces in different places of the file.