### PR TITLE
change type of notification recipients

### DIFF
--- a/shared/specs/notifications-openapi.yaml
+++ b/shared/specs/notifications-openapi.yaml
@@ -58,31 +58,22 @@ components:
     CreateBody:
       properties:
         recipients:
-          oneOf:
-            - type: object
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - 'broadcast'
-              required: ["type"]
-            - type: object
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - 'entity'
-                entityRef:
-                  type: array
-                  items:
-                    type: string
-                excludeEntityRef:
-                  oneOf:
-                    - type: string
-                    - type: array
-                      items:
-                        type: string
-              required: ["type", "entityRef"]
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - 'broadcast'
+                - 'entity'
+            entityRef:
+              type: array
+              items:
+                type: string
+            excludeEntityRef:
+              type: array
+              items:
+                type: string
+          required: ["type"]
         payload:
           $ref: '#/components/schemas/NotificationPayload'
     Notification:


### PR DESCRIPTION
the typescript code uses an OR between two types for defining the recipients object
java openapi generator i used in command line deals with it properly.
quarkus does not
therefore, switching to a more intuitive and simple type declaration in openapi spec