### PR TITLE
Use konveyor image in e2e for move2kube instance

### DIFF
--- a/e2e/resources/move2kube-instance.yaml
+++ b/e2e/resources/move2kube-instance.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: move2kube-instance
-          image: quay.io/orchestrator/move2kube-ui:latest
+          image: quay.io/konveyor/move2kube-ui:v0.3.13
           securityContext:
             runAsUser: 0
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/FLPATH-1355


Use konveyor image in e2e for move2kube instance

Same as https://github.com/parodos-dev/serverless-workflows-config/pull/299