### PR TITLE
Make github action for move2kube work on the tip of the PR

### DIFF
--- a/.github/workflows/move2kube-e2e.yaml
+++ b/.github/workflows/move2kube-e2e.yaml
@@ -2,7 +2,7 @@ name: Move2kube Workflow end to end tests
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:


### PR DESCRIPTION
`on: pull_request_target` is not suitable for actions that build because
it operates on the last commit on the base branch - https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

`on: pull_request` works on the last commit of the PR branch -  https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request

The change does effect the current workflows execution

Signed-off-by: Roy Golan <rgolan@redhat.com>
