### PR TITLE
Revert "pipeline: Conditionally add a LICENSE file if it exists (#310)"

### DIFF
--- a/pipeline/workflow-builder.Dockerfile
+++ b/pipeline/workflow-builder.Dockerfile
@@ -49,15 +49,7 @@ COPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/
 COPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/*.jar /deployments/
 COPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/app/ /deployments/app/
 COPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/quarkus/ /deployments/quarkus/
-
-# Copy the license file if it exists in the context
-RUN --mount=type=bind,target=/context,Z <<EOF
-if [ -f /context/LICENSE ]; then
-    mkdir /licenses
-    cp -v /context/LICENSE /licenses
-fi
-EOF
-
+COPY LICENSE /licenses/
 
 EXPOSE 8080
 USER 185


### PR DESCRIPTION
We have 2 usages of the pipeline that fails due to various buildah
issues:
1. The tekton pipeline the orchestrator-helm-chart or operator installs
   is having a what looks like a fusefs problem bind mounting the
   context. Perhaps a buildah bug.
2. GH actions using an older version of buildah (1.23) which doesn't
   support the RUN --mount option, which was introduced at 1.25.

KONFLUX build will fail the build as /licences/LICENSE is a mandatory
part of the build, and we have to address that in some other way,
preferably not introducing a new Dockerfile

This reverts commit deef258ae5813d672590b5cd3c7c80ad2e9308ed.

flpath-1484
