### PR TITLE
konflux: execute konflux build only on label ok-to-test-konflux

### DIFF
--- a/.tekton/move2kube-serverless-workflow-pull-request.yaml
+++ b/.tekton/move2kube-serverless-workflow-pull-request.yaml
@@ -7,8 +7,9 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "move2kube/***".pathChanged() || ".tekton/move2kube-serverless-workflow-pull-request.yaml".pathChanged()
+    pipelinesascode.tekton.dev/on-comment: "^/ok-to-test-konflux$"
+    pipelinesascode.tekton.dev/on-cel-expression: target_branch == "main"
+      && ( "move2kube/***".pathChanged() || ".tekton/move2kube-serverless-workflow-pull-request.yaml".pathChanged()
       || "pipeline/workflow-builder.Dockerfile".pathChanged() )
   creationTimestamp: null
   labels:

--- a/move2kube/README.md
+++ b/move2kube/README.md
@@ -1,3 +1,4 @@
+ test change to trigger change - don't commit this
 # Move2kube (m2k) workflow
 ## Context
 This workflow is using https://move2kube.konveyor.io/ to migrate the existing code contained in a git repository to a K8s/OCP platform.


### PR DESCRIPTION
To prevent tons of useless and wasteful konflux pipeline executions, and
to prevent ddos of konflux by bad actors, use a label to trigger a run
by konflux.

Signed-off-by: Roy Golan <rgolan@redhat.com>
