### PR TITLE
Update workflow-builder.Dockerfile

### DIFF
--- a/create-ocp-project/argfile.conf
+++ b/create-ocp-project/argfile.conf
@@ -1,4 +1,4 @@
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-serverless-1/logic-swf-builder-rhel8@sha256:838593bd7907e317f0a2f1183441d3b3edcdc830e06a292f92eb25b437fa4955
+BUILDER_IMAGE=
 
 # FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
 QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.100.0.redhat-00004,org.kie:kie-addons-quarkus-persistence-jdbc:9.100.0.redhat-00004,io.quarkus:quarkus-jdbc-postgresql:3.8.4.redhat-00002,io.quarkus:quarkus-agroal:3.8.4.redhat-00002

--- a/escalation/argfile.conf
+++ b/escalation/argfile.conf
@@ -1,4 +1,4 @@
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-serverless-1/logic-swf-builder-rhel8@sha256:838593bd7907e317f0a2f1183441d3b3edcdc830e06a292f92eb25b437fa4955
+BUILDER_IMAGE=
 
 # FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
 QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.100.0.redhat-00004,org.kie:kie-addons-quarkus-persistence-jdbc:9.100.0.redhat-00004,io.quarkus:quarkus-jdbc-postgresql:3.8.4.redhat-00002,io.quarkus:quarkus-agroal:3.8.4.redhat-00002

--- a/escalation/jira-listener/argfile.conf
+++ b/escalation/jira-listener/argfile.conf
@@ -1,4 +1,4 @@
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-serverless-1/logic-swf-builder-rhel8@sha256:838593bd7907e317f0a2f1183441d3b3edcdc830e06a292f92eb25b437fa4955
+BUILDER_IMAGE=
 
 # FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
 QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.100.0.redhat-00004,org.kie:kie-addons-quarkus-persistence-jdbc:9.100.0.redhat-00004,io.quarkus:quarkus-jdbc-postgresql:3.8.4.redhat-00002,io.quarkus:quarkus-agroal:3.8.4.redhat-00002

--- a/greeting/argfile.conf
+++ b/greeting/argfile.conf
@@ -1,4 +1,4 @@
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-serverless-1/logic-swf-builder-rhel8@sha256:838593bd7907e317f0a2f1183441d3b3edcdc830e06a292f92eb25b437fa4955
+BUILDER_IMAGE=
 
 # FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
 QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.100.0.redhat-00004,org.kie:kie-addons-quarkus-persistence-jdbc:9.100.0.redhat-00004,io.quarkus:quarkus-jdbc-postgresql:3.8.4.redhat-00002,io.quarkus:quarkus-agroal:3.8.4.redhat-00002

--- a/modify-vm-resources/argfile.conf
+++ b/modify-vm-resources/argfile.conf
@@ -1,4 +1,4 @@
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-serverless-1/logic-swf-builder-rhel8@sha256:838593bd7907e317f0a2f1183441d3b3edcdc830e06a292f92eb25b437fa4955
+BUILDER_IMAGE=
 
 # FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
 QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.100.0.redhat-00004,org.kie:kie-addons-quarkus-persistence-jdbc:9.100.0.redhat-00004,io.quarkus:quarkus-jdbc-postgresql:3.8.4.redhat-00002,io.quarkus:quarkus-agroal:3.8.4.redhat-00002

--- a/move2kube/argfile.conf
+++ b/move2kube/argfile.conf
@@ -1,4 +1,4 @@
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-serverless-1/logic-swf-builder-rhel8@sha256:838593bd7907e317f0a2f1183441d3b3edcdc830e06a292f92eb25b437fa4955
+BUILDER_IMAGE=
 
 # FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
 QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.100.0.redhat-00004,org.kie:kie-addons-quarkus-persistence-jdbc:9.100.0.redhat-00004,io.quarkus:quarkus-jdbc-postgresql:3.8.4.redhat-00002,io.quarkus:quarkus-agroal:3.8.4.redhat-00002

--- a/mta-v6.x/argfile.conf
+++ b/mta-v6.x/argfile.conf
@@ -1,4 +1,4 @@
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-serverless-1/logic-swf-builder-rhel8@sha256:838593bd7907e317f0a2f1183441d3b3edcdc830e06a292f92eb25b437fa4955
+BUILDER_IMAGE=
 
 # FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
 QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.100.0.redhat-00004,org.kie:kie-addons-quarkus-persistence-jdbc:9.100.0.redhat-00004,io.quarkus:quarkus-jdbc-postgresql:3.8.4.redhat-00002,io.quarkus:quarkus-agroal:3.8.4.redhat-00002

--- a/mta-v7.x/argfile.conf
+++ b/mta-v7.x/argfile.conf
@@ -1,4 +1,4 @@
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-serverless-1/logic-swf-builder-rhel8@sha256:838593bd7907e317f0a2f1183441d3b3edcdc830e06a292f92eb25b437fa4955
+BUILDER_IMAGE=
 
 # FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
 QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.100.0.redhat-00004,org.kie:kie-addons-quarkus-persistence-jdbc:9.100.0.redhat-00004,io.quarkus:quarkus-jdbc-postgresql:3.8.4.redhat-00002,io.quarkus:quarkus-agroal:3.8.4.redhat-00002

--- a/mta/argfile.conf
+++ b/mta/argfile.conf
@@ -1,4 +1,4 @@
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-serverless-1/logic-swf-builder-rhel8@sha256:838593bd7907e317f0a2f1183441d3b3edcdc830e06a292f92eb25b437fa4955
+BUILDER_IMAGE=
 
 # FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
 QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.100.0.redhat-00004,org.kie:kie-addons-quarkus-persistence-jdbc:9.100.0.redhat-00004,io.quarkus:quarkus-jdbc-postgresql:3.8.4.redhat-00002,io.quarkus:quarkus-agroal:3.8.4.redhat-00002

--- a/mtv-migration/argfile.conf
+++ b/mtv-migration/argfile.conf
@@ -1,4 +1,4 @@
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-serverless-1/logic-swf-builder-rhel8@sha256:838593bd7907e317f0a2f1183441d3b3edcdc830e06a292f92eb25b437fa4955
+BUILDER_IMAGE=
 
 # FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
 QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.100.0.redhat-00004,org.kie:kie-addons-quarkus-persistence-jdbc:9.100.0.redhat-00004,io.quarkus:quarkus-jdbc-postgresql:3.8.4.redhat-00002,io.quarkus:quarkus-agroal:3.8.4.redhat-00002

--- a/mtv-plan/argfile.conf
+++ b/mtv-plan/argfile.conf
@@ -1,4 +1,4 @@
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-serverless-1/logic-swf-builder-rhel8@sha256:838593bd7907e317f0a2f1183441d3b3edcdc830e06a292f92eb25b437fa4955
+BUILDER_IMAGE=
 
 # FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
 QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.100.0.redhat-00004,org.kie:kie-addons-quarkus-persistence-jdbc:9.100.0.redhat-00004,io.quarkus:quarkus-jdbc-postgresql:3.8.4.redhat-00002,io.quarkus:quarkus-agroal:3.8.4.redhat-00002

--- a/pipeline/workflow-builder.Dockerfile
+++ b/pipeline/workflow-builder.Dockerfile
@@ -4,7 +4,7 @@
 ARG BUILDER_IMAGE
 
 # The default builder image is the released OSL 1.33 https://catalog.redhat.com/software/containers/openshift-serverless-1/logic-swf-builder-rhel8/6614edd826a5be569c111884?container-tabs=gti
-FROM ${BUILDER_IMAGE:-registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8@sha256:6defe106ef355b2d0bd55224564ae6eafb4bb3ac081f8dc9ee410fb05216112d} AS builder
+FROM ${BUILDER_IMAGE:-registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8@sha256:5c624eff9780d08409a446d76a1bbe88c91ea98a6428883a170303e8de40c78a} AS builder
 
 # Temp hack to provide persistence artifacts - with quay.io/kiegroup/kogito-swf-builder:9.99.1.CR1 those dependencies are included in the base image.
 #ENV MAVEN_REPO_URL=https://maven.repository.redhat.com/earlyaccess/all
@@ -36,7 +36,7 @@ RUN /home/kogito/launch/build-app.sh ./resources
 #=============================
 # Runtime Run
 #=============================
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.20-2.1721752931
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.20-2.1724037299
 
 
 ARG FLOW_NAME

--- a/request-vm-cnv/argfile.conf
+++ b/request-vm-cnv/argfile.conf
@@ -1,4 +1,4 @@
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-serverless-1/logic-swf-builder-rhel8@sha256:838593bd7907e317f0a2f1183441d3b3edcdc830e06a292f92eb25b437fa4955
+BUILDER_IMAGE=
 
 # FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
 QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.100.0.redhat-00004,org.kie:kie-addons-quarkus-persistence-jdbc:9.100.0.redhat-00004,io.quarkus:quarkus-jdbc-postgresql:3.8.4.redhat-00002,io.quarkus:quarkus-agroal:3.8.4.redhat-00002


### PR DESCRIPTION
Bump the latest builder image  1.33 respin
Bump the latest runtime openjdk 17 image 

I removed all the brew images in the argflie.conf because we use the official builder image which is maintained and there is no more need to use a private build for konflux

FLPATH-1641
https://issues.redhat.com/browse/FLPATH-1641