### PR TITLE
Revert changes to move2kube instance

### DIFF
--- a/.github/workflows/move2kube-e2e.yaml
+++ b/.github/workflows/move2kube-e2e.yaml
@@ -121,7 +121,7 @@ jobs:
           
           kubectl patch configmap/m2k-props \
             --type merge \
-            -p '{"data": {"application.properties" :"move2kube_url=http://move2kube-instance-svc.default.svc.cluster.local:8080\nquarkus.rest-client.move2kube_yaml.url=http://move2kube-instance-svc.move2kube.svc.cluster.local:8080\nquarkus.rest-client.notifications.url=http://orchestrator-backstage.default.svc.cluster.local:7007/"}}'
+            -p '{"data": {"application.properties" :"move2kube_url=http://move2kube-instance-svc.default.svc.cluster.local:8080\nquarkus.rest-client.move2kube_yaml.url=http://move2kube-instance-svc.default.svc.cluster.local:8080\nquarkus.rest-client.notifications.url=http://orchestrator-backstage.default.svc.cluster.local:7007/"}}'
           kubectl delete pod -l "app=m2k"
           kubectl get pods -o wide
           kubectl wait --for=condition=Ready=true pods -l "app=m2k" --timeout=1m

--- a/e2e/move2kube.sh
+++ b/e2e/move2kube.sh
@@ -34,7 +34,7 @@ sleep 3
 echo "Proxy Janus-idp port ✅"
 
 echo "Proxy move2kube instance port ⏳"
-kubectl port-forward  svc/move2kube-instance-svc 8080:8080 &
+kubectl port-forward svc/move2kube-instance-svc 8080:8080 &
 move2kube_port_forward_pid="$!"
 sleep 3
 echo "Proxy move2kube instance port ✅"


### PR DESCRIPTION
The move2kube instance is being created in the default namespace in the
testing.
However, when it is deployed by the helm chart, the user may select any
namespace, while the default namespace is `move2kube`.

Caused by https://github.com/parodos-dev/serverless-workflows/pull/386

Signed-off-by: Moti Asayag <masayag@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED