### PR TITLE
Drop the global build-arg QUARKUS_EXTENSIONS from the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,6 @@ $(WORKFLOWS):
 # Empty value is used to work with the default builder image from the dockerfile.
 BUILDER_IMAGE = ""
 
-# Empty value is used to work with the default quarkus extensions list from the dockerfile.
-QUARKUS_EXTENSIONS = ""
-
 ifndef APPLICATION_ID
 APPLICATION_ID = UNDEFINED
 endif
@@ -126,7 +123,7 @@ prepare-workdir:
 # Depends on: prepare-workdir target.
 # Usage: make build-image
 ifeq ($(IS_WORKFLOW),true)
-build-image: BUILD_ARGS=--build-arg-file=$(WORKFLOW_ID)/argfile.conf --build-arg=BUILDER_IMAGE=$(BUILDER_IMAGE) --build-arg=QUARKUS_EXTENSIONS=$(QUARKUS_EXTENSIONS) --build-arg WF_RESOURCES=$(WORKFLOW_ID)
+build-image: BUILD_ARGS=--build-arg-file=$(WORKFLOW_ID)/argfile.conf --build-arg=BUILDER_IMAGE=$(BUILDER_IMAGE) --build-arg WF_RESOURCES=$(WORKFLOW_ID)
 endif
 build-image: EXTRA_ARGS=--ulimit nofile=4096:4096
 build-image: prepare-workdir

--- a/pipeline/workflow-builder.Dockerfile
+++ b/pipeline/workflow-builder.Dockerfile
@@ -6,7 +6,6 @@ ARG BUILDER_IMAGE
 # The default builder image is the released OSL 1.33 https://catalog.redhat.com/software/containers/openshift-serverless-1/logic-swf-builder-rhel8/6614edd826a5be569c111884?container-tabs=gti
 FROM ${BUILDER_IMAGE:-registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8@sha256:5c624eff9780d08409a446d76a1bbe88c91ea98a6428883a170303e8de40c78a} AS builder
 
-# Temp hack to provide persistence artifacts - with quay.io/kiegroup/kogito-swf-builder:9.99.1.CR1 those dependencies are included in the base image.
 #ENV MAVEN_REPO_URL=https://maven.repository.redhat.com/earlyaccess/all
 
 # variables that can be overridden by the builder


### PR DESCRIPTION
Workflows were missing persistency since the introduction of build-arg
usage in the makefile.

This is not really used and sending an empty value override the value in
argfile. Removing as this is not used and is too clever.

Signed-off-by: Roy Golan <rgolan@redhat.com>
