### PR TITLE
adding support for large YAML files as input

### DIFF
--- a/pipeline/workflow-builder.Dockerfile
+++ b/pipeline/workflow-builder.Dockerfile
@@ -18,7 +18,9 @@ ARG QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.100
 
 # Additional java/mvn arguments to pass to the builder.
 # This are is conventient to pass sonataflow and quarkus build time properties.
-ARG MAVEN_ARGS_APPEND="-Dkogito.persistence.type=jdbc -Dquarkus.datasource.db-kind=postgresql -Dkogito.persistence.proto.marshaller=false"
+# Note that the maxYamlCodePoints parameter contols the maximum input size for 
+#   YAML input files, and is currently set to 35000000 characters (~33MB in UTF-8).  
+ARG MAVEN_ARGS_APPEND="-DmaxYamlCodePoints=35000000 -Dkogito.persistence.type=jdbc -Dquarkus.datasource.db-kind=postgresql -Dkogito.persistence.proto.marshaller=false"
 
 # Argument for passing the resources folder if not current context dir
 ARG WF_RESOURCES


### PR DESCRIPTION
This change adds a build time param for the serverless workflow dockerfile that allows passing YAML input files to a workflow with an unlimited size. This change comes in handy when we might use large openAPI spec files.
This change has been tested using a [custom image](https://quay.io/repository/eshalev/serverless-workflow-greeting?tab=tags) built using this suggested change, and validated that the workflow does accept the arge input.

A reproducer for this fix can be seen [here.](https://github.com/parodos-dev/serverless-workflows/compare/main...ElaiShalevRH:serverless-workflows:yaml-build-param)

For full discretion, using large input files with this parameter may cause the workflow execution time to be slower.