### PR TITLE
MTA: add exitMessage in errorMessage metadata

### DIFF
--- a/mta-v7.x/mta.sw.yaml
+++ b/mta-v7.x/mta.sw.yaml
@@ -435,7 +435,7 @@ states:
   - name: NotifyFailureBackstage
     type: operation
     metadata:
-      errorMessage: '"MTA analysis for " + .application.repository.url + " failed. Check logs of task pod: " + .taskgroup.tasks[0].pod'
+      errorMessage: '"MTA analysis for " + .application.repository.url + " failed: " + .exitMessage + ". Check logs of task pod: " + .taskgroup.tasks[0].pod'
     actions:
       - functionRef:
           refName: createNotification


### PR DESCRIPTION
Follow up of https://github.com/parodos-dev/serverless-workflows/pull/405

MTA: add exitMessage in errorMessage metadata