### PR TITLE
Replace type array by anyOf

### DIFF
--- a/shared/schemas/workflow-result-schema.json
+++ b/shared/schemas/workflow-result-schema.json
@@ -49,9 +49,13 @@
                     },
                     "value": {
                         "description": "Free form value of the option.",
-                        "type": [
-                            "string",
-                            "number"
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "number"
+                            }
                         ]
                     },
                     "format": {


### PR DESCRIPTION
No matter the array should be valid type, it fails parsing. Changing to semnatically identical use of "anyOf" instead.