### PR TITLE
Remove trailing white spaces from application.properties

### DIFF
--- a/create-ocp-project/application.properties
+++ b/create-ocp-project/application.properties
@@ -17,8 +17,8 @@ quarkus.kubernetes-client.trust-certs=true
 quarkus.flyway.migrate-at-start=true
 
 # This property is used to select the log level, which controls the amount
-# of information logged on HTTP requests based on the severity of the events. 
-# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL. 
-# and see https://quarkus.io/guides/logging for documentation 
+# of information logged on HTTP requests based on the severity of the events.
+# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.
+# and see https://quarkus.io/guides/logging for documentation
 quarkus.log.category."org.apache.http".level=INFO
 quarkus.log.level=INFO

--- a/escalation/application.properties
+++ b/escalation/application.properties
@@ -27,9 +27,9 @@ quarkus.rest-client.notifications.url=${BACKSTAGE_NOTIFICATIONS_URL:http://backs
 quarkus.openapi-generator.notifications.auth.BearerToken.bearer-token=${NOTIFICATIONS_BEARER_TOKEN}
 
 # This property is used to select the log level, which controls the amount
-# of information logged on HTTP requests based on the severity of the events. 
-# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL. 
-# and see https://quarkus.io/guides/logging for documentation 
+# of information logged on HTTP requests based on the severity of the events.
+# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.
+# and see https://quarkus.io/guides/logging for documentation
 quarkus.log.category."org.apache.http".level=INFO
 quarkus.log.level=INFO
 

--- a/greeting/application.properties
+++ b/greeting/application.properties
@@ -1,6 +1,6 @@
 # This property is used to select the log level, which controls the amount
-# of information logged on HTTP requests based on the severity of the events. 
-# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL. 
-# and see https://quarkus.io/guides/logging for documentation 
+# of information logged on HTTP requests based on the severity of the events.
+# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.
+# and see https://quarkus.io/guides/logging for documentation
 quarkus.log.category."org.apache.http".level=INFO
 quarkus.log.level=INFO

--- a/modify-vm-resources/application.properties
+++ b/modify-vm-resources/application.properties
@@ -20,8 +20,8 @@ quarkus.kubernetes-client.trust-certs=true
 quarkus.flyway.migrate-at-start=true
 
 # This property is used to select the log level, which controls the amount
-# of information logged on HTTP requests based on the severity of the events. 
-# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL. 
-# and see https://quarkus.io/guides/logging for documentation 
+# of information logged on HTTP requests based on the severity of the events.
+# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.
+# and see https://quarkus.io/guides/logging for documentation
 quarkus.log.category."org.apache.http".level=INFO
 quarkus.log.level=INFO

--- a/move2kube/application.properties
+++ b/move2kube/application.properties
@@ -16,8 +16,8 @@ quarkus.rest-client.notifications.url=${BACKSTAGE_NOTIFICATIONS_URL:http://backs
 quarkus.openapi-generator.notifications.auth.BearerToken.bearer-token=${NOTIFICATIONS_BEARER_TOKEN}
 
 # This property is used to select the log level, which controls the amount
-# of information logged on HTTP requests based on the severity of the events. 
-# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL. 
-# and see https://quarkus.io/guides/logging for documentation 
+# of information logged on HTTP requests based on the severity of the events.
+# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.
+# and see https://quarkus.io/guides/logging for documentation
 quarkus.log.category."org.apache.http".level=INFO
 quarkus.log.level=INFO

--- a/mta-v6.x/application.properties
+++ b/mta-v6.x/application.properties
@@ -7,8 +7,8 @@ quarkus.rest-client.notifications.url=${BACKSTAGE_NOTIFICATIONS_URL:http://backs
 quarkus.openapi-generator.notifications.auth.BearerToken.bearer-token=${NOTIFICATIONS_BEARER_TOKEN}
 
 # This property is used to select the log level, which controls the amount
-# of information logged on HTTP requests based on the severity of the events. 
-# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL. 
-# and see https://quarkus.io/guides/logging for documentation 
+# of information logged on HTTP requests based on the severity of the events.
+# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.
+# and see https://quarkus.io/guides/logging for documentation
 quarkus.log.category."org.apache.http".level=INFO
 quarkus.log.level=INFO

--- a/mta-v7.x/application.properties
+++ b/mta-v7.x/application.properties
@@ -7,8 +7,8 @@ quarkus.rest-client.notifications.url=${BACKSTAGE_NOTIFICATIONS_URL:http://backs
 quarkus.openapi-generator.notifications.auth.BearerToken.bearer-token=${NOTIFICATIONS_BEARER_TOKEN}
 
 # This property is used to select the log level, which controls the amount
-# of information logged on HTTP requests based on the severity of the events. 
-# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL. 
-# and see https://quarkus.io/guides/logging for documentation 
+# of information logged on HTTP requests based on the severity of the events.
+# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.
+# and see https://quarkus.io/guides/logging for documentation
 quarkus.log.category."org.apache.http".level=INFO
 quarkus.log.level=INFO

--- a/mta/application.properties
+++ b/mta/application.properties
@@ -9,8 +9,8 @@ quarkus.rest-client.notifications.url=${BACKSTAGE_NOTIFICATIONS_URL:http://backs
 quarkus.openapi-generator.notifications.auth.BearerToken.bearer-token=${NOTIFICATIONS_BEARER_TOKEN}
 
 # This property is used to select the log level, which controls the amount
-# of information logged on HTTP requests based on the severity of the events. 
-# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL. 
-# and see https://quarkus.io/guides/logging for documentation 
+# of information logged on HTTP requests based on the severity of the events.
+# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.
+# and see https://quarkus.io/guides/logging for documentation
 quarkus.log.category."org.apache.http".level=INFO
 quarkus.log.level=INFO

--- a/mtv-migration/application.properties
+++ b/mtv-migration/application.properties
@@ -6,8 +6,8 @@ quarkus.tls.trust-all=true
 quarkus.kubernetes-client.trust-certs=true
 
 # This property is used to select the log level, which controls the amount
-# of information logged on HTTP requests based on the severity of the events. 
-# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL. 
-# and see https://quarkus.io/guides/logging for documentation 
+# of information logged on HTTP requests based on the severity of the events.
+# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.
+# and see https://quarkus.io/guides/logging for documentation
 quarkus.log.category."org.apache.http".level=INFO
 quarkus.log.level=INFO

--- a/mtv-plan/application.properties
+++ b/mtv-plan/application.properties
@@ -6,8 +6,8 @@ quarkus.tls.trust-all=true
 quarkus.kubernetes-client.trust-certs=true
 
 # This property is used to select the log level, which controls the amount
-# of information logged on HTTP requests based on the severity of the events. 
-# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL. 
-# and see https://quarkus.io/guides/logging for documentation 
+# of information logged on HTTP requests based on the severity of the events.
+# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.
+# and see https://quarkus.io/guides/logging for documentation
 quarkus.log.category."org.apache.http".level=INFO
 quarkus.log.level=INFO

--- a/request-vm-cnv/application.properties
+++ b/request-vm-cnv/application.properties
@@ -20,8 +20,8 @@ quarkus.kubernetes-client.trust-certs=true
 quarkus.flyway.migrate-at-start=true
 
 # This property is used to select the log level, which controls the amount
-# of information logged on HTTP requests based on the severity of the events. 
-# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL. 
-# and see https://quarkus.io/guides/logging for documentation 
+# of information logged on HTTP requests based on the severity of the events.
+# Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.
+# and see https://quarkus.io/guides/logging for documentation
 quarkus.log.category."org.apache.http".level=INFO
 quarkus.log.level=INFO


### PR DESCRIPTION
This seems to cause a rendering issue for the configmap generated by the kn-workflow CLI.

Signed-off-by: Moti Asayag <masayag@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED