### PR TITLE
removed .inputs. as schema changed

### DIFF
--- a/modify-vm-resources/modify-vm-resources.sw.yaml
+++ b/modify-vm-resources/modify-vm-resources.sw.yaml
@@ -28,18 +28,18 @@ functions:
   - name: fillEmptyValues
     type: expression
     operation: '{
-      vm_new_memory:(if (.inputs.vm_new_memory == null or
-      .inputs.vm_new_memory =="") then
-      .vm.spec.template.spec.domain.memory.guest else .inputs.vm_new_memory
+      vm_new_memory:(if (.vm_new_memory == null or
+      .vm_new_memory =="") then
+      .vm.spec.template.spec.domain.memory.guest else .vm_new_memory
       end),
-      vm_new_cpu_cores:(if .inputs.vm_new_cpu_cores == null then
-      .vm.spec.template.spec.domain.cpu.cores else .inputs.vm_new_cpu_cores
+      vm_new_cpu_cores:(if .vm_new_cpu_cores == null then
+      .vm.spec.template.spec.domain.cpu.cores else .vm_new_cpu_cores
       end),
-      vm_new_cpu_sockets:(if .inputs.vm_new_cpu_sockets == null then
-      .vm.spec.template.spec.domain.cpu.sockets else .inputs.vm_new_cpu_sockets
+      vm_new_cpu_sockets:(if .vm_new_cpu_sockets == null then
+      .vm.spec.template.spec.domain.cpu.sockets else .vm_new_cpu_sockets
       end),
-      vm_new_cpu_threads:if .inputs.vm_new_cpu_threads == null then
-      .vm.spec.template.spec.domain.cpu.threads else .inputs.vm_new_cpu_threads
+      vm_new_cpu_threads:if .vm_new_cpu_threads == null then
+      .vm.spec.template.spec.domain.cpu.threads else .vm_new_cpu_threads
       end
       }'
 start: Get VM


### PR DESCRIPTION
modify vm workflow input schema has changed, but some references in the workflow were yet to be replaced. This has caused a bug when running the workflow - the workflow succeeded but is failing to accept input data and actually use it.  