### PR TITLE
Create OCP Project: change openapi spec to stick to OCP behaviour

### DIFF
--- a/create-ocp-project/create-ocp-project.sw.yaml
+++ b/create-ocp-project/create-ocp-project.sw.yaml
@@ -21,8 +21,8 @@ functions:
     operation: specs/jira-openapi.yaml#getIssueTransitions
   - name: createNotification
     operation: notifications#createNotification
-  - name: createProjectOpenshiftIoV1Project
-    operation: specs/ocp-project-openapi.yaml#createProjectOpenshiftIoV1Project
+  - name: createProjectRequestOpenshiftIoV1Project
+    operation: specs/ocp-project-openapi.yaml#createProjectRequestOpenshiftIoV1Project
   - name: readProjectOpenshiftIoV1Project
     operation: specs/ocp-project-openapi.yaml#readProjectOpenshiftIoV1Project
   - name: print
@@ -148,9 +148,9 @@ states:
     actions:
       - name: "Create OCP Project"
         functionRef:
-          refName: createProjectOpenshiftIoV1Project
+          refName: createProjectRequestOpenshiftIoV1Project
           arguments:
-            kind: Project
+            kind: ProjectRequest
             metadata:
               labels:
                 kubernetes.io/metadata.name: .projectName

--- a/create-ocp-project/specs/ocp-project-openapi.yaml
+++ b/create-ocp-project/specs/ocp-project-openapi.yaml
@@ -7,12 +7,12 @@ servers:
 security:
 - BearerToken: []
 paths:
-  /apis/project.openshift.io/v1/projects:
+  /apis/project.openshift.io/v1/projectrequests:
     post:
       tags:
       - projectOpenshiftIo_v1
       description: create a Project
-      operationId: createProjectOpenshiftIoV1Project
+      operationId: createProjectRequestOpenshiftIoV1Project
       parameters:
       - name: pretty
         in: query
@@ -55,7 +55,7 @@ paths:
         content:
           '*/*':
             schema:
-              $ref: '#/components/schemas/com.github.openshift.api.project.v1.Project'
+              $ref: '#/components/schemas/com.github.openshift.api.project.v1.ProjectRequest'
         required: true
       responses:
         "200":
@@ -63,37 +63,37 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/com.github.openshift.api.project.v1.Project'
+                $ref: '#/components/schemas/com.github.openshift.api.project.v1.ProjectRequest'
             application/yaml:
               schema:
-                $ref: '#/components/schemas/com.github.openshift.api.project.v1.Project'
+                $ref: '#/components/schemas/com.github.openshift.api.project.v1.ProjectRequest'
             application/vnd.kubernetes.protobuf:
               schema:
-                $ref: '#/components/schemas/com.github.openshift.api.project.v1.Project'
+                $ref: '#/components/schemas/com.github.openshift.api.project.v1.ProjectRequest'
         "201":
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/com.github.openshift.api.project.v1.Project'
+                $ref: '#/components/schemas/com.github.openshift.api.project.v1.ProjectRequest'
             application/yaml:
               schema:
-                $ref: '#/components/schemas/com.github.openshift.api.project.v1.Project'
+                $ref: '#/components/schemas/com.github.openshift.api.project.v1.ProjectRequest'
             application/vnd.kubernetes.protobuf:
               schema:
-                $ref: '#/components/schemas/com.github.openshift.api.project.v1.Project'
+                $ref: '#/components/schemas/com.github.openshift.api.project.v1.ProjectRequest'
         "202":
           description: Accepted
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/com.github.openshift.api.project.v1.Project'
+                $ref: '#/components/schemas/com.github.openshift.api.project.v1.ProjectRequest'
             application/yaml:
               schema:
-                $ref: '#/components/schemas/com.github.openshift.api.project.v1.Project'
+                $ref: '#/components/schemas/com.github.openshift.api.project.v1.ProjectRequest'
             application/vnd.kubernetes.protobuf:
               schema:
-                $ref: '#/components/schemas/com.github.openshift.api.project.v1.Project'
+                $ref: '#/components/schemas/com.github.openshift.api.project.v1.ProjectRequest'
         "401":
           description: Unauthorized
           content: {}


### PR DESCRIPTION
Create OCP Project: change openapi spec to stick to OCP behaviour when creating OCP project

See https://github.com/parodos-dev/serverless-workflows-config/pull/924/files#r1826159768