### PR TITLE
Fix infra swf output: must be in result object

### DIFF
--- a/create-ocp-project/create-ocp-project.sw.yaml
+++ b/create-ocp-project/create-ocp-project.sw.yaml
@@ -31,27 +31,33 @@ functions:
   - name: successResult
     type: expression
     operation: '{
-        "completedWith":"success",
-        "message": "Project " + .projectName + " active",
-        "outputs":[]
+        "result": {
+          "completedWith":"success",
+          "message": "Project " + .projectName + " active",
+          "outputs":[]
+        }
       }'
   - name: errorProjectNotActiveResult
     type: expression
     operation: '{
-        "completedWith":"error",
-        "message": "Project " + .projectName + " not active"
+        "result": {
+          "completedWith":"error",
+          "message": "Project " + .projectName + " not active"
+        }
       }'
   - name: errorAuthorizationDeniedResult
     type: expression
     operation: '{
-        "completedWith":"error",
-        "message": "Creation of project " + .projectName + " denied",
-        "outputs":[
-          {
-              "key":"Jira issue",
-              "value": $SECRET.jira_url + "/jira/servicedesk/projects/" + .operationsProjectKey + "/issues/" + .operationsJiraCreateIssueResult.key,
-              "format":"link"
-          }]
+        "result": {
+          "completedWith":"error",
+          "message": "Creation of project " + .projectName + " denied",
+          "outputs":[
+            {
+                "key":"Jira issue",
+                "value": $SECRET.jira_url + "/jira/servicedesk/projects/" + .operationsProjectKey + "/issues/" + .operationsJiraCreateIssueResult.key,
+                "format":"link"
+            }]
+          }
       }'
 start: "[Audit]: workflow started"
 states:

--- a/extendable-workflow/extendable-workflow.sw.yaml
+++ b/extendable-workflow/extendable-workflow.sw.yaml
@@ -32,18 +32,20 @@ functions:
   - name: successResult
     type: expression
     operation: '{
-        "completedWith":"success",
-        "message": "Extendable workflow completed successfully",
-        "outputs":[
-          {
-              "key":"Selected language",
-              "value": .languageInfo.language
-          },
-          {
-              "key":"Greeting message",
-              "value": .greeting
-          }
-        ]
+        "result": {
+          "completedWith":"success",
+          "message": "Extendable workflow completed successfully",
+          "outputs":[
+            {
+                "key":"Selected language",
+                "value": .languageInfo.language
+            },
+            {
+                "key":"Greeting message",
+                "value": .greeting
+            }
+          ]
+        }
       }'
 states:
   - name: ChooseOnLanguage

--- a/greeting/greeting.sw.yaml
+++ b/greeting/greeting.sw.yaml
@@ -17,18 +17,20 @@ functions:
   - name: successResult
     type: expression
     operation: '{
-        "completedWith":"success",
-        "message": "Greeting workflow completed successfully",
-        "outputs":[
-          {
-              "key":"Selected language",
-              "value": .language
-          },
-          {
-              "key":"Greeting message",
-              "value": .greeting
-          }
-        ]
+        "result": {
+          "completedWith":"success",
+          "message": "Greeting workflow completed successfully",
+          "outputs":[
+            {
+                "key":"Selected language",
+                "value": .language
+            },
+            {
+                "key":"Greeting message",
+                "value": .greeting
+            }
+          ]
+        }
       }'
 states:
   - name: ChooseOnLanguage

--- a/modify-vm-resources/modify-vm-resources.sw.yaml
+++ b/modify-vm-resources/modify-vm-resources.sw.yaml
@@ -47,33 +47,39 @@ functions:
   - name: successResult
     type: expression
     operation: '{
-        "completedWith":"success",
-        "message": "VM" + .vm_name + " in namespace " + .vm_namespace + " updated.",
-        "outputs":[
-          {
-              "key":"Console URL",
-              "value": $SECRET.cluster_console_url + "/k8s/ns/" + .vm_namespace + "/kubevirt.io~v1~VirtualMachine/" + .vm_name + "/console/standalone",
-              "format":"link"
-          }
-        ]
+        "result": {
+          "completedWith":"success",
+          "message": "VM" + .vm_name + " in namespace " + .vm_namespace + " updated.",
+          "outputs":[
+            {
+                "key":"Console URL",
+                "value": $SECRET.cluster_console_url + "/k8s/ns/" + .vm_namespace + "/kubevirt.io~v1~VirtualMachine/" + .vm_name + "/console/standalone",
+                "format":"link"
+            }
+          ]
+        }
       }'
   - name: errorVMNotRunningResult
     type: expression
     operation: '{
-        "completedWith":"error",
-        "message": "VM" + .vm_name + " in namespace " + .vm_namespace + " not ready after the update after checking" + .vmStatusRunningRetries + " times: " + .vm.status
+        "result": {
+          "completedWith":"error",
+          "message": "VM" + .vm_name + " in namespace " + .vm_namespace + " not ready after the update after checking" + .vmStatusRunningRetries + " times: " + .vm.status
+        }
       }'
   - name: errorAuthorizationDeniedResult
     type: expression
     operation: '{
-        "completedWith":"error",
-        "message": "Authorization denied to update VM " + .vm_name + " in namespace " + .vm_namespace + ". Memory: " + .vm_new_memory + ". CPU cores: " + (.vm_new_cpu_cores|tostring) + ". CPU threads: " + (.vm_new_cpu_threads|tostring) + ". CPU sockets: " + (.vm_new_cpu_sockets|tostring),
-        "outputs":[
-          {
-              "key":"Jira issue",
-              "value": $SECRET.jira_url + "/jira/servicedesk/projects/" + .projectKey + "/issues/" + .jiraCreateIssueResult.key,
-              "format":"link"
-          }]
+        "result": {
+          "completedWith":"error",
+          "message": "Authorization denied to update VM " + .vm_name + " in namespace " + .vm_namespace + ". Memory: " + .vm_new_memory + ". CPU cores: " + (.vm_new_cpu_cores|tostring) + ". CPU threads: " + (.vm_new_cpu_threads|tostring) + ". CPU sockets: " + (.vm_new_cpu_sockets|tostring),
+          "outputs":[
+            {
+                "key":"Jira issue",
+                "value": $SECRET.jira_url + "/jira/servicedesk/projects/" + .projectKey + "/issues/" + .jiraCreateIssueResult.key,
+                "format":"link"
+            }]
+          }
       }'
 start: Get VM
 states:

--- a/move2kube/m2k.sw.yml
+++ b/move2kube/m2k.sw.yml
@@ -50,36 +50,40 @@ functions:
   - name: successResult
     type: expression
     operation: '{
-        "completedWith":"success",
-        "message": "Move2Kube workflow  " + $WORKFLOW.instanceId + " on workspace " + .workspaceId + " and project " + .projectId + " was successful; the output is available in the branch " + .targetBranch + " of your git repository "+ .repositoryURL,
-        "outputs": [
-          {
-              "key":"Git repository",
-              "value": .repositoryURL,
-              "format":"link"
-          },
-          {
-              "key":"Git branch",
-              "value": .targetBranch
-          }
-        ]
+        "result": {
+          "completedWith":"success",
+          "message": "Move2Kube workflow  " + $WORKFLOW.instanceId + " on workspace " + .workspaceId + " and project " + .projectId + " was successful; the output is available in the branch " + .targetBranch + " of your git repository "+ .repositoryURL,
+          "outputs": [
+            {
+                "key":"Git repository",
+                "value": .repositoryURL,
+                "format":"link"
+            },
+            {
+                "key":"Git branch",
+                "value": .targetBranch
+            }
+          ]
+        }
       }'
   - name: errorResult
     type: expression
     operation: '{
-        "completedWith":"error",
-        "message": "Move2Kube workflow  " + $WORKFLOW.instanceId + " on workspace " + .workspaceId + " and project " + .projectId + " failed ",
-        "outputs":[
-          {
-              "key":"Exit message",
-              "value": .exitMessage
-          },
-          {
-              "key":"Plan retries",
-              "value": (.planRetries|tostring),
-              "format":"number"
-          }
-        ]
+        "result": {
+          "completedWith":"error",
+          "message": "Move2Kube workflow  " + $WORKFLOW.instanceId + " on workspace " + .workspaceId + " and project " + .projectId + " failed ",
+          "outputs":[
+            {
+                "key":"Exit message",
+                "value": .exitMessage
+            },
+            {
+                "key":"Plan retries",
+                "value": (.planRetries|tostring),
+                "format":"number"
+            }
+          ]
+        }
       }'
 states:
   - name: StartPlanning

--- a/mtv-migration/mtv.sw.yaml
+++ b/mtv-migration/mtv.sw.yaml
@@ -28,21 +28,25 @@ functions:
   - name: successResult
     type: expression
     operation: '{
-        "completedWith":"success",
-        "message": "MTV migration " + .migrationName + " succeeded",
-        "outputs":[]
+        "result": {
+          "completedWith":"success",
+          "message": "MTV migration " + .migrationName + " succeeded",
+          "outputs":[]
+        }
       }'
   - name: errorResult
     type: expression
     operation: '{
-        "completedWith":"error",
-        "message": "MTV migration " + .migrationName + " failed.",
-        "outputs":[
-          {
-              "key":"Error",
-              "value": .migrationErrorMessage
-          }
-        ]
+        "result": {
+          "completedWith":"error",
+          "message": "MTV migration " + .migrationName + " failed.",
+          "outputs":[
+            {
+                "key":"Error",
+                "value": .migrationErrorMessage
+            }
+          ]
+        }
       }'
 states:
   - name: CreateMigration

--- a/request-vm-cnv/request-vm-cnv.sw.yaml
+++ b/request-vm-cnv/request-vm-cnv.sw.yaml
@@ -30,33 +30,39 @@ functions:
   - name: successResult
     type: expression
     operation: '{
-        "completedWith":"success",
-        "message": "VM" + .vm_name + " in namespace "+.vm_namespace + " using image "+ .vm_image +" ready and running.",
-        "outputs":[
-          {
-              "key":"Console URL",
-              "value": $SECRET.cluster_console_url + "/k8s/ns/" + .vm_namespace + "/kubevirt.io~v1~VirtualMachine/" + .vm_name + "/console/standalone",
-              "format":"link"
-          }
-        ]
+        "result": {
+          "completedWith":"success",
+          "message": "VM" + .vm_name + " in namespace "+.vm_namespace + " using image "+ .vm_image +" ready and running.",
+          "outputs":[
+            {
+                "key":"Console URL",
+                "value": $SECRET.cluster_console_url + "/k8s/ns/" + .vm_namespace + "/kubevirt.io~v1~VirtualMachine/" + .vm_name + "/console/standalone",
+                "format":"link"
+            }
+          ]
+        }
       }'
   - name: errorVMNotRunningResult
     type: expression
     operation: '{
-        "completedWith":"error",
-        "message": "VM" + .vm_name + " in namespace "+.vm_namespace + " using image "+ .vm_image +" not ready after "+ .vmStatusRunningRetries + " retries: " + .vm.status
+        "result": {
+          "completedWith":"error",
+          "message": "VM" + .vm_name + " in namespace "+.vm_namespace + " using image "+ .vm_image +" not ready after "+ .vmStatusRunningRetries + " retries: " + .vm.status
+        }
       }'
   - name: errorAuthorizationDeniedResult
     type: expression
     operation: '{
-        "completedWith":"error",
-        "message": "Authorization denied to create VM" + .vm_name + " in namespace "+.vm_namespace + " using image "+ .vm_image,
-        "outputs":[
-          {
-              "key":"Jira issue",
-              "value": $SECRET.jira_url + "/jira/servicedesk/projects/" + .projectKey + "/issues/" + .jiraCreateIssueResult.key,
-              "format":"link"
-          }]
+        "result": {
+          "completedWith":"error",
+          "message": "Authorization denied to create VM" + .vm_name + " in namespace "+.vm_namespace + " using image "+ .vm_image,
+          "outputs":[
+            {
+                "key":"Jira issue",
+                "value": $SECRET.jira_url + "/jira/servicedesk/projects/" + .projectKey + "/issues/" + .jiraCreateIssueResult.key,
+                "format":"link"
+            }]
+          }
       }'
 start: Open issue on JIRA
 states:


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/FLPATH-1795

Fix infra swf output: must be in result object and not directly into workflowData:
```
{
  "workflowdata": {
    "message": "Greeting workflow completed successfully",
    "outputs": [
      {
        "key": "Selected language",
        "value": "English"
      },
      {
        "key": "Greeting message",
        "value": "Hello from YAML Workflow"
      }
    ],
    "greeting": "Hello from YAML Workflow",
    "language": "English",
    "completedWith": "success"
  },
  "workflowdatainput": {
    "language": "English"
  }
}
```
must be
```
{
  "workflowdata": {
    "result": {
      "message": "Greeting workflow completed successfully",
      "outputs": [
        {
          "key": "Selected language",
          "value": "English"
        },
        {
          "key": "Greeting message",
          "value": "Hello from YAML Workflow"
        }
      ],
      "greeting": "Hello from YAML Workflow",
      "language": "English",
      "completedWith": "success"
    },
    "workflowdatainput": {
      "language": "English"
    }
   }
}
```