### PR TITLE
Move errorMessage metadata to the end state

### DIFF
--- a/workflows/mta-v7.x/mta.sw.yaml
+++ b/workflows/mta-v7.x/mta.sw.yaml
@@ -538,8 +538,6 @@ states:
     end: true
   - name: NotifyFailureBackstage
     type: operation
-    metadata:
-      errorMessage: '"MTA analysis for " + .application.repository.url + " failed: " + .exitMessage + ". Check logs of task pod: " + .taskgroup.tasks[0].pod'
     actions:
       - functionRef:
           refName: createNotification
@@ -555,6 +553,8 @@ states:
     transition: reportFailure
   - name: reportFailure
     type: operation
+    metadata:
+      errorMessage: '"MTA analysis for " + .application.repository.url + " failed: " + .exitMessage + ". Check logs of task pod: " + .taskgroup.tasks[0].pod'
     actions:
       - name: reportFailure
         functionRef:


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/FLPATH-1918

Move errorMessage metadata to the end state